### PR TITLE
Remove Japanese signs which shouldn't be contained in hash

### DIFF
--- a/markdown_toc.rb
+++ b/markdown_toc.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# coding: utf-8
 
 require 'cgi'
 
@@ -22,7 +23,7 @@ class Heading
   end
 
   def to_toc_item_line
-    section_name = CGI.escape(@text.downcase.gsub(' ', '-').gsub(/[!-,:-@\[-\^{-~.\/`]/, ''))
+    section_name = CGI.escape(@text.downcase.gsub(' ', '-').gsub(/[!-,:-@\[-\^{-~.\/`]/, '').gsub('、', '').gsub('「', '').gsub('」', ''))
     [
       INDENT_SPACES * (@level - 1),
       '- [',


### PR DESCRIPTION
This is similar fix for markdown_relative_link_checker
https://github.com/skirino/markdown_relative_link_checker/pull/2

As far as I tested, GitHub removes `、`, `「` and `」` when it create a link to a section.
Therefore, markdown_toc creates a wrong link for it.

Maybe, there are more signs which markdown_toc should remove, but this pull request removes signs which I already found.